### PR TITLE
Update webpack dependency to support 2.1.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "description": "Use webpack with karma and fast, file source maps",
   "peerDependencies": {
-    "webpack": "^1.4.0"
+    "webpack": "^1.4.0 || ^2.1.0-beta"
   },
   "dependencies": {
     "async": "~0.9.0",


### PR DESCRIPTION
Mimicking the babel-loader package.json, update the webpack peer dependency to support the 2.1.0-beta.
